### PR TITLE
Changed write permissions to FileAdapter

### DIFF
--- a/stm/adapter_file.go
+++ b/stm/adapter_file.go
@@ -25,7 +25,7 @@ func (adp *FileAdapter) Write(loc *Location, data []byte) {
 		log.Fatalf("[F] %s should be a directory", dir)
 	}
 
-	file, _ := os.OpenFile(loc.Path(), os.O_RDWR|os.O_CREATE, 0666)
+	file, _ := os.OpenFile(loc.Path(), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
 	fi, err = file.Stat()
 	if err != nil {
 		log.Fatalf("[F] %s file not exists", loc.Path())


### PR DESCRIPTION
I have been changed permissions to OpenFile in the FileAdapter, because generator do not cleans old data, if I re-generate sitemap. I think, you should use "truncate"-permission like ioutil.WriteFile do.
https://golang.org/src/io/ioutil/ioutil.go?s=2520:2588#L66
Anyway, it helped in my case )