### PR TITLE
Add a webserver example to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,47 @@ func main() {
 }
 ```
 
+### Webserver example
+
+
+```go
+	package main
+
+	import (
+		"fmt"
+		"io/ioutil"
+		"log"
+		"net/http"
+	)
+	
+	func buildSitemap() {
+		sm := stm.NewSitemap()
+		sm.SetDefaultHost("http://example.com")
+
+		sm.Create()
+
+		sm.Add(stm.URL{"loc": "/", "changefreq": "daily"})
+
+		// Note: Do not call `sm.Finalize()` because it flushes
+		// the underlying datastructure from memory to disk.
+
+		return sm
+	}
+
+	func main() {
+		sm := buildSitemap()
+
+		r.HandleFunc("/sitemap.xml", func(w http.ResponseWriter, r *http.Request) {
+			// Go's webserver automatically sets the correct `Content-Type` header.
+			w.Write(sm.XMLContent())
+			return
+		})
+
+		log.Fatal(http.ListenAndServe(":8080", nil))
+	}
+```
+
+
 ### Documentation
 
 - [API Reference](https://godoc.org/github.com/ikeikeikeike/go-sitemap-generator/stm)

--- a/README.md
+++ b/README.md
@@ -284,6 +284,8 @@ func main() {
 		"io/ioutil"
 		"log"
 		"net/http"
+
+		"github.com/ikeikeikeike/go-sitemap-generator/stm"
 	)
 	
 	func buildSitemap() {


### PR DESCRIPTION
It took me a LONG time to figure out that I should not be calling `.Finalize()` for a basic webserver. I think that this example would help others. 