### PR TITLE
add sitemapsPath to the final URL in the sitemap index

### DIFF
--- a/stm/location.go
+++ b/stm/location.go
@@ -58,12 +58,10 @@ func (loc *Location) PathInPublic() string {
 func (loc *Location) URL() string {
 	base, _ := url.Parse(loc.opts.SitemapsHost())
 
-	var u *url.URL
 	for _, ref := range []string{
-		loc.opts.sitemapsPath, loc.Filename(),
+		loc.opts.sitemapsPath + "/", loc.Filename(),
 	} {
-		u, _ = url.Parse(ref)
-		base = base.ResolveReference(u)
+		base, _ = base.Parse(ref)
 	}
 
 	return base.String()


### PR DESCRIPTION
Let the base URL parse the relative paths, and add a slash to the end of sitemapsPath to make sure it will not be ignored.
This fixes sitemap URLs ignoring sitemapsPath var ex: `http://example.com/sitemap.xml` instead of  `http://example.com/sitemapsPath/sitemap.xml` 