### PR TITLE
Fix sitemap elements sequence

### DIFF
--- a/stm/builder_url.go
+++ b/stm/builder_url.go
@@ -88,9 +88,10 @@ func (su *sitemapURL) XML() []byte {
 	url := doc.CreateElement("url")
 
 	SetBuilderElementValue(url, su.data.URLJoinBy("loc", "host", "loc"), "loc")
-	SetBuilderElementValue(url, su.data, "expires")
-	SetBuilderElementValue(url, su.data, "mobile")
-
+	if _, ok := SetBuilderElementValue(url, su.data, "lastmod"); !ok {
+		lastmod := url.CreateElement("lastmod")
+		lastmod.SetText(time.Now().Format(time.RFC3339))
+	}
 	if _, ok := SetBuilderElementValue(url, su.data, "changefreq"); !ok {
 		changefreq := url.CreateElement("changefreq")
 		changefreq.SetText("weekly")
@@ -99,11 +100,8 @@ func (su *sitemapURL) XML() []byte {
 		priority := url.CreateElement("priority")
 		priority.SetText("0.5")
 	}
-	if _, ok := SetBuilderElementValue(url, su.data, "lastmod"); !ok {
-		lastmod := url.CreateElement("lastmod")
-		lastmod.SetText(time.Now().Format(time.RFC3339))
-	}
-
+	SetBuilderElementValue(url, su.data, "expires")
+	SetBuilderElementValue(url, su.data, "mobile")
 	SetBuilderElementValue(url, su.data, "news")
 	SetBuilderElementValue(url, su.data, "video")
 	SetBuilderElementValue(url, su.data, "image")


### PR DESCRIPTION
According to [sitemaps schema](https://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd)
The correct sequence to lastmod is right after loc, not after changefreq:
```xml
<xsd:sequence>
  <xsd:element name="loc" type="tLoc"/>
  <xsd:element name="lastmod" type="tLastmod" minOccurs="0"/>
  <xsd:element name="changefreq" type="tChangeFreq" minOccurs="0"/>
  <xsd:element name="priority" type="tPriority" minOccurs="0"/>
  <xsd:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="strict"/>
</xsd:sequence>
```