### PR TITLE
Change map into 2d interface slices so the generated xml will be in order

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ import (
 
 
 func main() {
-	sm := stm.NewSitemap()
+	sm := stm.NewSitemap(1)
 
 	// Create method must be that calls first this method in that before
 	// call to Add method on this struct.
 	sm.Create()
 
-	sm.Add(stm.URL{"loc": "home", "changefreq": "always", "mobile": true})
-	sm.Add(stm.URL{"loc": "readme"})
-	sm.Add(stm.URL{"loc": "aboutme", "priority": 0.1})
+	sm.Add(stm.URL{{"loc", "home"}, {"changefreq", "always"}, {"mobile", true}})
+	sm.Add(stm.URL{{"loc", "readme"}})
+	sm.Add(stm.URL{{"loc", "aboutme"}, {"priority", 0.1}})
 
 	sm.Finalize().PingSearchEngines()
 }
@@ -58,13 +58,24 @@ Current Features or To-Do
 
 ## Getting Started
 
+### Setting concurrency
+To disable concurrency, set number of CPUs to 1.
+```go
+sm := stm.NewSitemap(1)
+```
+
+If you want to set max CPUs that are available, set number of CPUs <= 0.
+```go
+sm := stm.NewSitemap(0)
+```
+
 ### Preventing Output
 
 To disable all non-essential output you can give `false` to `sm.SetVerbose`.
 To disable output in-code use the following:
 
 ```go
-sm := stm.NewSitemap()
+sm := stm.NewSitemap(1)
 sm.SetVerbose(false)
 ```
 
@@ -117,7 +128,7 @@ import (
 )
 
 func main() {
-	sm := stm.NewSitemap()
+	sm := stm.NewSitemap(1)
 	sm.SetDefaultHost("http://example.com")
 	sm.SetSitemapsPath("sitemap-generator") // default: public
 	sm.SetSitemapsHost("http://s3.amazonaws.com/sitemap-generator/")
@@ -130,9 +141,9 @@ func main() {
 
 	sm.Create()
 
-	sm.Add(stm.URL{"loc": "home", "changefreq": "always", "mobile": true})
-	sm.Add(stm.URL{"loc": "readme"})
-	sm.Add(stm.URL{"loc": "aboutme", "priority": 0.1})
+	sm.Add(stm.URL{{"loc", "home"}, {"changefreq", "always"}, {"mobile", true}})
+	sm.Add(stm.URL{{"loc", "readme"}})
+	sm.Add(stm.URL{{"loc", "aboutme"}, {"priority", 0.1}})
 
 	sm.Finalize().PingSearchEngines()
 }
@@ -141,18 +152,21 @@ func main() {
 ### News sitemaps
 
 ```go
-sm.Add(stm.URL{"loc": "/news", "news": stm.URL{
-	"publication": stm.URL{
-		"name":     "Example",
-		"language": "en",
+sm.Add(stm.URL{
+	{"loc", "/news"}, 
+	{"news", stm.URL{
+	{"publication", stm.URL{
+		{"name",     "Example"},
+		{"language", "en"},
 	},
-	"title":            "My Article",
-	"keywords":         "my article, articles about myself",
-	"stock_tickers":    "SAO:PETR3",
-	"publication_date": "2011-08-22",
-	"access":           "Subscription",
-	"genres":           "PressRelease",
-}})
+	},
+	{"title",            "My Article"},
+	{"keywords",         "my article, articles about myself"},
+	{"stock_tickers",    "SAO:PETR3"},
+	{"publication_date", "2011-08-22"},
+	{"access",           "Subscription"},
+	{"genres",           "PressRelease"},
+},},})
 ```
 
 Look at [Creating a Google News Sitemap](https://support.google.com/news/publisher/answer/74288) as required.
@@ -160,15 +174,19 @@ Look at [Creating a Google News Sitemap](https://support.google.com/news/publish
 ### Video sitemaps
 
 ```go
-sm.Add(stm.URL{"loc": "/videos", "video": stm.URL{
-	"thumbnail_loc": "http://www.example.com/video1_thumbnail.png",
-	"title":         "Title",
-	"description":   "Description",
-	"content_loc":   "http://www.example.com/cool_video.mpg",
-	"category":      "Category",
-	"tag":           []string{"one", "two", "three"},
-    "player_loc":    stm.Attrs{"https://example.com/p/flash/moogaloop/6.2.9/moogaloop.swf?clip_id=26", map[string]string{"allow_embed": "Yes", "autoplay": "autoplay=1"}},
-}})
+sm.Add(stm.URL{
+	{"loc", "/videos"}, 
+	{"video", stm.URL{
+	{"thumbnail_loc", "http://www.example.com/video1_thumbnail.png"},
+	{"title",         "Title"},
+	{"description",   "Description"},
+	{"content_loc",   "http://www.example.com/cool_video.mpg"},
+	{"category",      "Category"},
+	{"tag",           []string{"one", "two", "three"}},
+    {"player_loc",    stm.Attrs{"https://example.com/p/flash/moogaloop/6.2.9/moogaloop.swf?clip_id=26", map[string]string{"allow_embed": "Yes", "autoplay": "autoplay=1"}},},
+},
+},
+})
 ```
 
 Look at [Video sitemaps](https://support.google.com/webmasters/answer/80471) as required.
@@ -176,10 +194,13 @@ Look at [Video sitemaps](https://support.google.com/webmasters/answer/80471) as 
 ### Image sitemaps
 
 ```go
-sm.Add(stm.URL{"loc": "/images", "image": []stm.URL{
-	{"loc": "http://www.example.com/image.png", "title": "Image"},
-	{"loc": "http://www.example.com/image1.png", "title": "Image1"},
-}})
+sm.Add(stm.URL{
+	{"loc", "/images"}, 
+	{"image", []stm.URL{
+	{{"loc", "http://www.example.com/image.png"}, {"title", "Image"}},
+	{{"loc", "http://www.example.com/image1.png"}, {"title", "Image1"}},
+},},
+})
 
 ```
 
@@ -188,9 +209,12 @@ Look at [Image sitemaps](https://support.google.com/webmasters/answer/178636) as
 ### Geo sitemaps
 
 ```go
-sm.Add(stm.URL{"loc": "/geos", "geo": stm.URL{
-	"format": "kml",
-}})
+sm.Add(stm.URL{
+	{"loc", "/geos"}, 
+	{"geo", stm.URL{
+	{"format", "kml"},
+},},
+})
 ```
 
 Couldn't find Geo sitemaps example. Although its like a below.
@@ -207,7 +231,7 @@ Couldn't find Geo sitemaps example. Although its like a below.
 ### Mobile sitemaps
 
 ```go
-sm.Add(stm.URL{"loc": "mobiles", "mobile": true})
+sm.Add(stm.URL{{"loc", "mobiles"}, {"mobile", true}})
 ```
 
 Look at [Feature phone sitemaps](https://support.google.com/webmasters/answer/6082207) as required.
@@ -223,7 +247,7 @@ import (
 )
 
 func main() {
-	sm := stm.NewSitemap()
+	sm := stm.NewSitemap(0)
 	sm.SetDefaultHost("http://yourhost.com")
 	sm.SetSitemapsHost("http://s3.amazonaws.com/sitemaps/")
 	sm.SetSitemapsPath("sitemaps/")
@@ -234,41 +258,50 @@ func main() {
 
 	sm.Create()
 
-	sm.Add(stm.URL{"loc": "/home", "changefreq": "daily"})
+	sm.Add(stm.URL{{"loc", "/home"}, {"changefreq", "daily"}})
 
-	sm.Add(stm.URL{"loc": "/abouts", "mobile": true})
+	sm.Add(stm.URL{{"loc", "/abouts"}, {"mobile", true}})
 
-	sm.Add(stm.URL{"loc": "/news", "news": stm.URL{
-		"publication": stm.URL{
-			"name":     "Example",
-			"language": "en",
+	sm.Add(stm.URL{{"loc", "/news"}, 
+	{"news", stm.URL{
+		{"publication", stm.URL{
+			{"name",     "Example"},
+			{"language", "en"},
 		},
-		"title":            "My Article",
-		"keywords":         "my article, articles about myself",
-		"stock_tickers":    "SAO:PETR3",
-		"publication_date": "2011-08-22",
-		"access":           "Subscription",
-		"genres":           "PressRelease",
-	}})
+		},
+		{"title",            "My Article"},
+		{"keywords",         "my article, articles about myself"},
+		{"stock_tickers",    "SAO:PETR3"},
+		{"publication_date", "2011-08-22"},
+		{"access",           "Subscription"},
+		{"genres",           "PressRelease"},
+	},},
+	})
 
-	sm.Add(stm.URL{"loc": "/images", "image": []stm.URL{
-		{"loc": "http://www.example.com/image.png", "title": "Image"},
-		{"loc": "http://www.example.com/image1.png", "title": "Image1"},
-	}})
+	sm.Add(stm.URL{{"loc", "/images"}, 
+	{"image", []stm.URL{
+		{{"loc", "http://www.example.com/image.png"}, {"title", "Image"}},
+		{{"loc", "http://www.example.com/image1.png"}, {"title", "Image1"}},
+	},},
+	})
 
-	sm.Add(stm.URL{"loc": "/videos", "video": stm.URL{
-		"thumbnail_loc": "http://www.example.com/video1_thumbnail.png",
-		"title":         "Title",
-		"description":   "Description",
-		"content_loc":   "http://www.example.com/cool_video.mpg",
-		"category":      "Category",
-		"tag":           []string{"one", "two", "three"},
-	    "player_loc":    stm.Attrs{"https://example.com/p/flash/moogaloop/6.2.9/moogaloop.swf?clip_id=26", map[string]string{"allow_embed": "Yes", "autoplay": "autoplay=1"}},
-	}})
+	sm.Add(stm.URL{{"loc", "/videos"}, 
+	{"video", stm.URL{
+		{"thumbnail_loc", "http://www.example.com/video1_thumbnail.png"},
+		{"title",         "Title"},
+		{"description",   "Description"},
+		{"content_loc",   "http://www.example.com/cool_video.mpg"},
+		{"category",      "Category"},
+		{"tag",           []string{"one", "two", "three"}},
+	    {"player_loc",    stm.Attrs{"https://example.com/p/flash/moogaloop/6.2.9/moogaloop.swf?clip_id=26", map[string]string{"allow_embed": "Yes", "autoplay": "autoplay=1"}}},
+	},},
+	})
 
-	sm.Add(stm.URL{"loc": "/geos", "geo": stm.URL{
-		"format": "kml",
-	}})
+	sm.Add(stm.URL{{"loc", "/geos"}, 
+	{"geo", stm.URL{
+		{"format", "kml"},
+	},},
+	})
 
 	sm.Finalize().PingSearchEngines("http://newengine.com/ping?url=%s")
 }
@@ -288,11 +321,11 @@ import (
 )
 
 func buildSitemap() *stm.Sitemap {
-	sm := stm.NewSitemap()
+	sm := stm.NewSitemap(1)
 	sm.SetDefaultHost("http://example.com")
 
 	sm.Create()
-	sm.Add(stm.URL{"loc": "/", "changefreq": "daily"})
+	sm.Add(stm.URL{{"loc", "/"}, {"changefreq", "daily"}})
 
 	// Note: Do not call `sm.Finalize()` because it flushes
 	// the underlying datastructure from memory to disk.

--- a/stm/builder.go
+++ b/stm/builder.go
@@ -1,8 +1,6 @@
 package stm
 
-import (
-	"fmt"
-)
+import "fmt"
 
 var poolBuffer = NewBufferPool()
 
@@ -32,16 +30,29 @@ type Attrs []interface{}
 type Attr map[string]string
 
 // URL User should use this typedef in main func.
-type URL map[string]interface{}
+type URL [][]interface{}
 
 // URLJoinBy that's convenient.
 func (u URL) URLJoinBy(key string, joins ...string) URL {
 	var values []string
 	for _, k := range joins {
-		values = append(values, fmt.Sprint(u[k]))
+		var vals interface{}
+		for _, v := range u {
+			if v[0] == k {
+				vals = v[1]
+				break
+			}
+		}
+		values = append(values, fmt.Sprint(vals))
 	}
-
-	u[key] = URLJoin("", values...)
+	var index int
+	var v []interface{}
+	for index, v = range u {
+		if v[0] == key {
+			break
+		}
+	}
+	u[index][1] = URLJoin("", values...)
 	return u
 }
 
@@ -51,10 +62,23 @@ func (u *URL) BungURLJoinBy(key string, joins ...string) {
 
 	var values []string
 	for _, k := range joins {
-		values = append(values, fmt.Sprint(orig[k]))
+		var vals interface{}
+		for _, v := range *u {
+			if v[0] == k {
+				vals = v[1]
+				break
+			}
+		}
+		values = append(values, fmt.Sprint(vals))
 	}
-
-	orig[key] = URLJoin("", values...)
+	var index int
+	var v []interface{}
+	for index, v = range *u {
+		if v[0] == key {
+			break
+		}
+	}
+	orig[index][1] = URLJoin("", values...)
 	*u = orig
 }
 

--- a/stm/builder_file.go
+++ b/stm/builder_file.go
@@ -35,7 +35,7 @@ type BuilderFile struct {
 // Add method joins old bytes with creates bytes by it calls from Sitemap.Add method.
 func (b *BuilderFile) Add(url interface{}) BuilderError {
 	u := MergeMap(url.(URL),
-		URL{"host": b.loc.opts.defaultHost},
+		URL{{"host", b.loc.opts.defaultHost}},
 	)
 
 	b.linkcnt++

--- a/stm/builder_indexfile.go
+++ b/stm/builder_indexfile.go
@@ -21,7 +21,7 @@ func (b *BuilderIndexfile) Add(link interface{}) BuilderError {
 	bldr := link.(*BuilderFile)
 	bldr.Write()
 
-	smu := NewSitemapIndexURL(b.opts, URL{"loc": bldr.loc.URL()})
+	smu := NewSitemapIndexURL(b.opts, URL{{"loc", bldr.loc.URL()}})
 	b.content = append(b.content, smu.XML()...)
 
 	b.totalcnt += bldr.linkcnt

--- a/stm/builder_test.go
+++ b/stm/builder_test.go
@@ -6,8 +6,8 @@ import (
 )
 
 func TestURLType(t *testing.T) {
-	url := URL{"loc": "1", "host": "http://example.com"}
-	expect := URL{"loc": "http://example.com/1", "host": "http://example.com"}
+	url := URL{{"loc", "1"}, {"host", "http://example.com"}}
+	expect := URL{{"loc", "http://example.com/1"}, {"host", "http://example.com"}}
 
 	url = url.URLJoinBy("loc", "host", "loc")
 
@@ -15,8 +15,8 @@ func TestURLType(t *testing.T) {
 		t.Fatalf("Failed to join url in URL type: deferrent URL %v and %v", url, expect)
 	}
 
-	url = URL{"loc": "1", "host": "http://example.com", "mobile": true}
-	expect = URL{"loc": "http://example.com/1/true", "host": "http://example.com", "mobile": true}
+	url = URL{{"loc", "1"}, {"host", "http://example.com"}, {"mobile", true}}
+	expect = URL{{"loc", "http://example.com/1/true"}, {"host", "http://example.com"}, {"mobile", true}}
 
 	url.BungURLJoinBy("loc", "host", "loc", "mobile")
 

--- a/stm/builder_url.go
+++ b/stm/builder_url.go
@@ -53,8 +53,17 @@ type sitemapURL struct {
 func (su *sitemapURL) validate() error {
 	var key string
 	var invalid bool
+	var locOk, hostOk bool
 
-	for key = range su.data {
+	for _, value := range su.data {
+		key = value[0].(string)
+		switch key {
+		case "loc":
+			locOk = true
+		case "host":
+			hostOk = true
+		}
+
 		invalid = true
 		for _, name := range fieldnames {
 			if key == name {
@@ -71,11 +80,11 @@ func (su *sitemapURL) validate() error {
 		msg := fmt.Sprintf("Unknown map's key `%s` in URL type", key)
 		return errors.New(msg)
 	}
-	if _, ok := su.data["loc"]; !ok {
+	if !locOk {
 		msg := fmt.Sprintf("URL type must have `loc` map's key")
 		return errors.New(msg)
 	}
-	if _, ok := su.data["host"]; !ok {
+	if !hostOk {
 		msg := fmt.Sprintf("URL type must have `host` map's key")
 		return errors.New(msg)
 	}

--- a/stm/builder_url_test.go
+++ b/stm/builder_url_test.go
@@ -23,7 +23,7 @@ func TestItHasLocElement(t *testing.T) {
 }
 
 func TestJustSetLocElement(t *testing.T) {
-	smu, err := NewSitemapURL(&Options{}, URL{"loc": "path", "host": "http://example.com"})
+	smu, err := NewSitemapURL(&Options{}, URL{{"loc", "path"}, {"host", "http://example.com"}})
 
 	if err != nil {
 		t.Fatalf(`Fatal to validate! This is a critical error: %s`, err)
@@ -45,7 +45,7 @@ func TestJustSetLocElement(t *testing.T) {
 }
 
 func TestJustSetLocElementAndThenItNeedsCompleteValues(t *testing.T) {
-	smu, err := NewSitemapURL(&Options{}, URL{"loc": "path", "host": "http://example.com"})
+	smu, err := NewSitemapURL(&Options{}, URL{{"loc", "path"}, {"host", "http://example.com"}})
 
 	if err != nil {
 		t.Fatalf(`Fatal to validate! This is a critical error: %s`, err)
@@ -93,7 +93,7 @@ func TestJustSetLocElementAndThenItNeedsCompleteValues(t *testing.T) {
 }
 
 func TestSetNilValue(t *testing.T) {
-	smu, err := NewSitemapURL(&Options{}, URL{"loc": "path", "priority": nil, "changefreq": nil, "lastmod": nil, "host": "http://example.com"})
+	smu, err := NewSitemapURL(&Options{}, URL{{"loc", "path"}, {"priority", nil}, {"changefreq", nil}, {"lastmod", nil}, {"host", "http://example.com"}})
 
 	if err != nil {
 		t.Fatalf(`Fatal to validate! This is a critical error: %s`, err)
@@ -130,7 +130,7 @@ func TestSetNilValue(t *testing.T) {
 }
 
 func TestAutoGenerateSitemapHost(t *testing.T) {
-	smu, err := NewSitemapURL(&Options{}, URL{"loc": "path", "host": "http://example.com"})
+	smu, err := NewSitemapURL(&Options{}, URL{{"loc", "path"}, {"host", "http://example.com"}})
 
 	if err != nil {
 		t.Fatalf(`Fatal to validate! This is a critical error: %s`, err)
@@ -155,18 +155,18 @@ func TestNewsSitemaps(t *testing.T) {
 	doc := etree.NewDocument()
 	root := doc.CreateElement("root")
 
-	data := URL{"loc": "/news", "news": URL{
-		"publication": URL{
-			"name":     "Example",
-			"language": "en",
-		},
-		"title":            "My Article",
-		"keywords":         "my article, articles about myself",
-		"stock_tickers":    "SAO:PETR3",
-		"publication_date": "2011-08-22",
-		"access":           "Subscription",
-		"genres":           "PressRelease",
-	}}
+	data := URL{{"loc", "/news"}, {"news", URL{
+		{"publication", URL{
+			{"name", "Example"},
+			{"language", "en"},
+		}},
+		{"title", "My Article"},
+		{"keywords", "my article, articles about myself"},
+		{"stock_tickers", "SAO:PETR3"},
+		{"publication_date", "2011-08-22"},
+		{"access", "Subscription"},
+		{"genres", "PressRelease"},
+	}}}
 	expect := []byte(`
 	<root>
 		<news:news>
@@ -199,10 +199,10 @@ func TestImageSitemaps(t *testing.T) {
 	doc := etree.NewDocument()
 	root := doc.CreateElement("root")
 
-	data := URL{"loc": "/images", "image": []URL{
-		{"loc": "http://www.example.com/image.png", "title": "Image"},
-		{"loc": "http://www.example.com/image1.png", "title": "Image1"},
-	}}
+	data := URL{{"loc", "/images"}, {"image", []URL{
+		{{"loc", "http://www.example.com/image.png"}, {"title", "Image"}},
+		{{"loc", "http://www.example.com/image1.png"}, {"title", "Image1"}},
+	}}}
 	expect := []byte(`
 	<root>
 		<image:image>
@@ -231,14 +231,14 @@ func TestVideoSitemaps(t *testing.T) {
 	doc := etree.NewDocument()
 	root := doc.CreateElement("root")
 
-	data := URL{"loc": "/videos", "video": URL{
-		"thumbnail_loc": "http://www.example.com/video1_thumbnail.png",
-		"title":         "Title",
-		"description":   "Description",
-		"content_loc":   "http://www.example.com/cool_video.mpg",
-		"category":      "Category",
-		"tag":           []string{"one", "two", "three"},
-	}}
+	data := URL{{"loc", "/videos"}, {"video", URL{
+		{"thumbnail_loc", "http://www.example.com/video1_thumbnail.png"},
+		{"title", "Title"},
+		{"description", "Description"},
+		{"content_loc", "http://www.example.com/cool_video.mpg"},
+		{"category", "Category"},
+		{"tag", []string{"one", "two", "three"}},
+	}}}
 
 	expect := []byte(`
 	<root>
@@ -270,7 +270,7 @@ func TestGeoSitemaps(t *testing.T) {
 	doc := etree.NewDocument()
 	root := doc.CreateElement("root")
 
-	data := URL{"loc": "/geos", "geo": URL{"format": "kml"}}
+	data := URL{{"loc", "/geos"}, {"geo", URL{{"format", "kml"}}}}
 
 	expect := []byte(`
 	<root>
@@ -295,7 +295,7 @@ func TestMobileSitemaps(t *testing.T) {
 	doc := etree.NewDocument()
 	root := doc.CreateElement("root")
 
-	data := URL{"loc": "/mobile", "mobile": true}
+	data := URL{{"loc", "/mobile"}, {"mobile", true}}
 
 	expect := []byte(`
 	<root>
@@ -325,15 +325,15 @@ func TestAttr(t *testing.T) {
 	doc := etree.NewDocument()
 	root := doc.CreateElement("root")
 
-	data := URL{"loc": "/videos", "video": URL{
-		"thumbnail_loc": "http://www.example.com/video1_thumbnail.png",
-		"title":         "Title",
-		"description":   "Description",
-		"content_loc":   "http://www.example.com/cool_video.mpg",
-		"category":      "Category",
-		"tag":           []string{"one", "two", "three"},
-		"player_loc":    Attrs{"https://f.vimeocdn.com/p/flash/moogaloop/6.2.9/moogaloop.swf?clip_id=26", Attr{"allow_embed": "Yes", "autoplay": "autoplay=1"}},
-	}}
+	data := URL{{"loc", "/videos"}, {"video", URL{
+		{"thumbnail_loc", "http://www.example.com/video1_thumbnail.png"},
+		{"title", "Title"},
+		{"description", "Description"},
+		{"content_loc", "http://www.example.com/cool_video.mpg"},
+		{"category", "Category"},
+		{"tag", []string{"one", "two", "three"}},
+		{"player_loc", Attrs{"https://f.vimeocdn.com/p/flash/moogaloop/6.2.9/moogaloop.swf?clip_id=26", Attr{"allow_embed": "Yes", "autoplay": "autoplay=1"}}},
+	}}}
 
 	expect := []byte(`
 	<root>
@@ -370,15 +370,15 @@ func TestAttrWithoutTypedef(t *testing.T) {
 	doc := etree.NewDocument()
 	root := doc.CreateElement("root")
 
-	data := URL{"loc": "/videos", "video": URL{
-		"thumbnail_loc": "http://www.example.com/video1_thumbnail.png",
-		"title":         "Title",
-		"description":   "Description",
-		"content_loc":   "http://www.example.com/cool_video.mpg",
-		"category":      "Category",
-		"tag":           []string{"one", "two", "three"},
-		"player_loc":    Attrs{"https://f.vimeocdn.com/p/flash/moogaloop/6.2.9/moogaloop.swf?clip_id=26", map[string]string{"allow_embed": "Yes", "autoplay": "autoplay=1"}},
-	}}
+	data := URL{{"loc", "/videos"}, {"video", URL{
+		{"thumbnail_loc", "http://www.example.com/video1_thumbnail.png"},
+		{"title", "Title"},
+		{"description", "Description"},
+		{"content_loc", "http://www.example.com/cool_video.mpg"},
+		{"category", "Category"},
+		{"tag", []string{"one", "two", "three"}},
+		{"player_loc", Attrs{"https://f.vimeocdn.com/p/flash/moogaloop/6.2.9/moogaloop.swf?clip_id=26", map[string]string{"allow_embed": "Yes", "autoplay": "autoplay=1"}}},
+	}}}
 
 	expect := []byte(`
 	<root>
@@ -424,40 +424,40 @@ func BenchmarkGenerateXML(b *testing.B) {
 			var smu SitemapURL
 			var data URL
 
-			data = URL{"loc": "/mobile", "mobile": true}
+			data = URL{{"loc", "/mobile"}, {"mobile", true}}
 			smu, _ = NewSitemapURL(&Options{}, data)
 			smu.XML()
 
-			data = URL{"loc": "/images", "image": []URL{
-				{"loc": "http://www.example.com/image.png", "title": "Image"},
-				{"loc": "http://www.example.com/image1.png", "title": "Image1"},
-			}}
+			data = URL{{"loc", "/images"}, {"image", []URL{
+				{{"loc", "http://www.example.com/image.png"}, {"title", "Image"}},
+				{{"loc", "http://www.example.com/image1.png"}, {"title", "Image1"}},
+			}}}
 			smu, _ = NewSitemapURL(&Options{}, data)
 			smu.XML()
 
-			data = URL{"loc": "/videos", "video": URL{
-				"thumbnail_loc": "http://www.example.com/video1_thumbnail.png",
-				"title":         "Title",
-				"description":   "Description",
-				"content_loc":   "http://www.example.com/cool_video.mpg",
-				"category":      "Category",
-				"tag":           []string{"one", "two", "three"},
-			}}
+			data = URL{{"loc", "/videos"}, {"video", URL{
+				{"thumbnail_loc", "http://www.example.com/video1_thumbnail.png"},
+				{"title", "Title"},
+				{"description", "Description"},
+				{"content_loc", "http://www.example.com/cool_video.mpg"},
+				{"category", "Category"},
+				{"tag", []string{"one", "two", "three"}},
+			}}}
 			smu, _ = NewSitemapURL(&Options{}, data)
 			smu.XML()
 
-			data = URL{"loc": "/news", "news": URL{
-				"publication": URL{
-					"name":     "Example",
-					"language": "en",
-				},
-				"title":            "My Article",
-				"keywords":         "my article, articles about myself",
-				"stock_tickers":    "SAO:PETR3",
-				"publication_date": "2011-08-22",
-				"access":           "Subscription",
-				"genres":           "PressRelease",
-			}}
+			data = URL{{"loc", "/news"}, {"news", URL{
+				{"publication", URL{
+					{"name", "Example"},
+					{"language", "en"},
+				}},
+				{"title", "My Article"},
+				{"keywords", "my article, articles about myself"},
+				{"stock_tickers", "SAO:PETR3"},
+				{"publication_date", "2011-08-22"},
+				{"access", "Subscription"},
+				{"genres", "PressRelease"},
+			}}}
 
 			smu, _ = NewSitemapURL(&Options{}, data)
 			smu.XML()

--- a/stm/sitemap.go
+++ b/stm/sitemap.go
@@ -6,9 +6,13 @@ import (
 )
 
 // NewSitemap returns the created the Sitemap's pointer
-func NewSitemap() *Sitemap {
+func NewSitemap(maxProc int) *Sitemap {
 	log.SetFlags(log.LstdFlags | log.Llongfile)
-	runtime.GOMAXPROCS(runtime.NumCPU())
+	if maxProc < 1 || maxProc > runtime.NumCPU() {
+		maxProc = runtime.NumCPU()
+	}
+	log.Printf("Max processors %d\n", maxProc)
+	runtime.GOMAXPROCS(maxProc)
 
 	sm := &Sitemap{
 		opts: NewOptions(),

--- a/stm/utils.go
+++ b/stm/utils.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/beevik/etree"
-	"github.com/imdario/mergo"
 )
 
 // BufferPool is
@@ -41,7 +40,7 @@ func (bp *BufferPool) Put(b *bytes.Buffer) {
 
 // SetBuilderElementValue if it will change to struct from map if the future's
 // author is feeling a bothersome in this function.
-func SetBuilderElementValue(elm *etree.Element, data map[string]interface{}, basekey string) (*etree.Element, bool) {
+func SetBuilderElementValue(elm *etree.Element, data [][]interface{}, basekey string) (*etree.Element, bool) {
 	var child *etree.Element
 
 	key := basekey
@@ -54,86 +53,105 @@ func SetBuilderElementValue(elm *etree.Element, data map[string]interface{}, bas
 		key = fmt.Sprintf("%s:%s", sk, basekey)
 	}
 
-	if values, ok := data[basekey]; ok {
-		switch value := values.(type) {
-		case nil:
-		default:
-			child = elm.CreateElement(key)
-			child.SetText(fmt.Sprint(value))
-		case int:
-			child = elm.CreateElement(key)
-			child.SetText(fmt.Sprint(value))
-		case string:
-			child = elm.CreateElement(key)
-			child.SetText(value)
-		case float64, float32:
-			child = elm.CreateElement(key)
-			child.SetText(fmt.Sprint(value))
-		case time.Time:
-			child = elm.CreateElement(key)
-			child.SetText(value.Format(time.RFC3339))
-		case bool:
-			_ = elm.CreateElement(fmt.Sprintf("%s:%s", key, key))
-		case []int:
-			for _, v := range value {
-				child = elm.CreateElement(key)
-				child.SetText(fmt.Sprint(v))
-			}
-		case []string:
-			for _, v := range value {
-				child = elm.CreateElement(key)
-				child.SetText(v)
-			}
-		case Attrs:
-			val, attrs := value[0], value[1]
+	var values interface{}
+	var found bool
+	for _, v := range data {
+		if v[0] == basekey {
+			values = v[1]
+			found = true
+			break
+		}
+	}
+	if !found {
+		return child, false
+	}
 
-			child, _ = SetBuilderElementValue(elm, URL{basekey: val}, basekey)
-			switch attr := attrs.(type) {
-			case map[string]string:
-				for k, v := range attr {
-					child.CreateAttr(k, v)
-				}
-			// TODO: gotta remove below
-			case Attr:
-				for k, v := range attr {
-					child.CreateAttr(k, v)
-				}
-			}
+	switch value := values.(type) {
+	case nil:
+	default:
+		child = elm.CreateElement(key)
+		child.SetText(fmt.Sprint(value))
+	case int:
+		child = elm.CreateElement(key)
+		child.SetText(fmt.Sprint(value))
+	case string:
+		child = elm.CreateElement(key)
+		child.SetText(value)
+	case float64, float32:
+		child = elm.CreateElement(key)
+		child.SetText(fmt.Sprint(value))
+	case time.Time:
+		child = elm.CreateElement(key)
+		child.SetText(value.Format(time.RFC3339))
+	case bool:
+		_ = elm.CreateElement(fmt.Sprintf("%s:%s", key, key))
+	case []int:
+		for _, v := range value {
+			child = elm.CreateElement(key)
+			child.SetText(fmt.Sprint(v))
+		}
+	case []string:
+		for _, v := range value {
+			child = elm.CreateElement(key)
+			child.SetText(v)
+		}
+	case Attrs:
+		val, attrs := value[0], value[1]
 
-		case interface{}:
-			var childkey string
-			if sk == "" {
-				childkey = fmt.Sprintf("%s:%s", key, key)
-			} else {
-				childkey = fmt.Sprint(key)
+		child, _ = SetBuilderElementValue(elm, URL{[]interface{}{basekey, val}}, basekey)
+		switch attr := attrs.(type) {
+		case map[string]string:
+			for k, v := range attr {
+				child.CreateAttr(k, v)
 			}
-
-			switch value := values.(type) {
-			case []URL:
-				for _, v := range value {
-					child := elm.CreateElement(childkey)
-					for ck := range v {
-						SetBuilderElementValue(child, v, ck)
-					}
-				}
-			case URL:
-				child := elm.CreateElement(childkey)
-				for ck := range value {
-					SetBuilderElementValue(child, value, ck)
-				}
+		// TODO: gotta remove below
+		case Attr:
+			for k, v := range attr {
+				child.CreateAttr(k, v)
 			}
 		}
 
-		return child, true
-	}
+	case interface{}:
+		var childkey string
+		if sk == "" {
+			childkey = fmt.Sprintf("%s:%s", key, key)
+		} else {
+			childkey = fmt.Sprint(key)
+		}
 
-	return child, false
+		switch value := values.(type) {
+		case []URL:
+			for _, val := range value {
+				child := elm.CreateElement(childkey)
+				for _, v := range val {
+					SetBuilderElementValue(child, val, v[0].(string))
+				}
+			}
+		case URL:
+			child := elm.CreateElement(childkey)
+			for _, v := range value {
+				SetBuilderElementValue(child, value, v[0].(string))
+			}
+		}
+	}
+	return child, true
 }
 
 // MergeMap TODO: Slow function: It wants to change fast function
-func MergeMap(src, dst map[string]interface{}) map[string]interface{} {
-	mergo.MapWithOverwrite(&dst, src)
-	return dst
+func MergeMap(src, dst [][]interface{}) [][]interface{} {
+	for _, v := range dst {
+		found := false
+		for _, vSrc := range src {
+			if v[0] == vSrc[0] {
+				found = true
+				break
+			}
+		}
+		if !found {
+			src = append(src, v)
+		}
+	}
+	return src
 }
 
 // ToLowerString converts lower strings from including capital or upper strings.

--- a/stm/utils_test.go
+++ b/stm/utils_test.go
@@ -6,14 +6,14 @@ import (
 )
 
 func TestMergeMap(t *testing.T) {
-	var src, dst, expect map[string]interface{}
-	src = map[string]interface{}{"loc": "1", "changefreq": "2", "mobile": true, "host": "http://google.com"}
-	dst = map[string]interface{}{"host": "http://example.com"}
-	expect = map[string]interface{}{"loc": "1", "changefreq": "2", "mobile": true, "host": "http://google.com"}
+	var src, dst, expect [][]interface{}
+	src = [][]interface{}{{"loc", "1"}, {"changefreq", "2"}, {"mobile", true}, {"host", "http://google.com"}}
+	dst = [][]interface{}{{"host", "http://example.com"}}
+	expect = [][]interface{}{{"loc", "1"}, {"changefreq", "2"}, {"mobile", true}, {"host", "http://google.com"}}
 
 	src = MergeMap(src, dst)
 
 	if !reflect.DeepEqual(src, expect) {
-		t.Fatalf("Failed to maps merge: deferrent map %v and %v", src, expect)
+		t.Fatalf("Failed to maps merge: deferrent map \n%#v\n and \n%#v\n", src, expect)
 	}
 }


### PR DESCRIPTION
We needed to change the map into slices in go-sitemap-generator library and to disable concurrency. The change was needed because map is storing values in random order, so the **output XML is not valid against XSDs**. This change was done for the purposes of The Economist.

The library now allows to set the max number of processors (concurrency). If it is set to 1 it will not use concurrency, if it is set to lower then 1, it will use maxCPUs available.

I used 2d interfaces slice [][]interface{} - it will enable to process sitemap same way as they were processed. The format how to write the item when adding into sitemap has changed due to this change.

The change to slices is faster forPerformance 500 in Benchmark test. 

Origin benchmark (with usage of map):
```goos: darwin
goarch: amd64
pkg: github.com/EconomistDigitalSolutions/go-sitemap-generator/stm
BenchmarkGenerateXML-4   	       1	16766094832 ns/op	8880786240 B/op	117012061 allocs/op
PASS
ok  	github.com/EconomistDigitalSolutions/go-sitemap-generator/stm	16.786s
Success: Benchmarks passed.
```

New benchmark (with usage of 2d slice of interfaces):
```goos: darwin
goarch: amd64
pkg: github.com/EconomistDigitalSolutions/cp-worker-format-sitemaps/vendor/github.com/kosto1992/go-sitemap-generator/stm
BenchmarkGenerateXML-4   	       1	15243760666 ns/op	8550720128 B/op	122268424 allocs/op
PASS
ok  	github.com/EconomistDigitalSolutions/cp-worker-format-sitemaps/vendor/github.com/kosto1992/go-sitemap-generator/stm	15.277s
Success: Benchmarks passed.```
