### PR TITLE
Support Go Modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 language: go
 
 go:
-  - 1.5
-  - 1.6
-  - 1.7
-  - 1.8
-  - 1.9
-  - "1.10"
-  - "1.11"
+  - 1.9.x
+  - 1.10.x
+  - 1.11.x
 
 install:
   - go get golang.org/x/tools/cmd/cover

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 package main
 
 import (
-	"github.com/ikeikeikeike/go-sitemap-generator/stm"
+	"github.com/ikeikeikeike/go-sitemap-generator/v2/stm"
 )
 
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/ikeikeikeike/go-sitemap-generator/v2
+
+go 1.9
+
+require (
+	github.com/beevik/etree v1.0.1
+	github.com/clbanning/mxj v1.8.3
+	github.com/fatih/structs v1.1.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/beevik/etree v1.0.1 h1:lWzdj5v/Pj1X360EV7bUudox5SRipy4qZLjY0rhb0ck=
+github.com/beevik/etree v1.0.1/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
+github.com/clbanning/mxj v1.8.3 h1:2r/KCJi52w2MRz+K+UMa/1d7DdCjnLqYJfnbr7dYNWI=
+github.com/clbanning/mxj v1.8.3/go.mod h1:BVjHeAH+rl9rs6f+QIpeRl0tfu10SXn1pUSa5PVGJng=
+github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
+github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=


### PR DESCRIPTION
Hello,

Please consider supporting [Go Modules], the new packaging standard that will be adopted fully in Go 1.12. Experimental support is in Go 1.11 and the new module paths are supported in Go 1.9.7+ and Go 1.10.3+ in a read-only manner for backwards compatibility with all supported versions of Go.

Because this libraries external dependencies already support semver compatible tags, the `go.mod` file is fairly simple. The only other thing that would need to be done is to create a semver compatible tag after this patch is merged (eg. `v2.0.2`) to allow other things to pin to that version without having to use the special "incompatible" version string used for projects that are v2 and up but don't have the major version declared in the module line.

As part of this I have reduced the versions of Go this library is tested against to only supported versions of Go that receive security updates, and one more (1.9) because everything appeared to work there and it supported modules. Older versions of go however, should be able to use this package just as they did before since they'll ignore the mod file anyways.

Thank you for your consideration.

**EDIT:** my only concern is that I'm not sure what the canonical import path for this project is, the readme mentions both `github.com/ikeikeikeike/go-sitemap-generator` and `gopkg.in/ikeikeikeike/go-sitemap-generator.v2`. Modules provides some workarounds for the gopkg.in imports IIRC, but  it's probably worth having a canonical path all the same.

[Go Modules]: https://github.com/golang/go/wiki/Modules