### PR TITLE
Allow omission of url defaults

### DIFF
--- a/stm/builder_url.go
+++ b/stm/builder_url.go
@@ -97,15 +97,15 @@ func (su *sitemapURL) XML() []byte {
 	url := doc.CreateElement("url")
 
 	SetBuilderElementValue(url, su.data.URLJoinBy("loc", "host", "loc"), "loc")
-	if _, ok := SetBuilderElementValue(url, su.data, "lastmod"); !ok {
+	if _, ok := SetBuilderElementValue(url, su.data, "lastmod"); !ok && !su.opts.omitDefaultLastMod {
 		lastmod := url.CreateElement("lastmod")
 		lastmod.SetText(time.Now().Format(time.RFC3339))
 	}
-	if _, ok := SetBuilderElementValue(url, su.data, "changefreq"); !ok {
+	if _, ok := SetBuilderElementValue(url, su.data, "changefreq"); !ok && !su.opts.omitDefaultChangeFreq {
 		changefreq := url.CreateElement("changefreq")
 		changefreq.SetText("weekly")
 	}
-	if _, ok := SetBuilderElementValue(url, su.data, "priority"); !ok {
+	if _, ok := SetBuilderElementValue(url, su.data, "priority"); !ok && !su.opts.omitDefaultPriority {
 		priority := url.CreateElement("priority")
 		priority.SetText("0.5")
 	}

--- a/stm/builder_url_test.go
+++ b/stm/builder_url_test.go
@@ -448,6 +448,48 @@ func TestAttrWithoutTypedef(t *testing.T) {
 	}
 }
 
+func TestOmitDefaults(t *testing.T) {
+	opts := Options{}
+	opts.SetOmitDefaultLastMod(true)
+	opts.SetOmitDefaultPriority(true)
+	opts.SetOmitDefaultChangeFreq(true)
+
+	smu, err := NewSitemapURL(&opts, URL{{"loc", "path"}, {"host", "http://example.com"}})
+
+	if err != nil {
+		t.Fatalf(`Fatal to validate! This is a critical error: %v`, err)
+	}
+
+	doc := etree.NewDocument()
+	doc.ReadFromBytes(smu.XML())
+
+	var elm *etree.Element
+	url := doc.SelectElement("url")
+
+	elm = url.SelectElement("loc")
+	if elm == nil {
+		t.Errorf(`Failed to generate xml that loc element is blank: %v`, elm)
+	}
+	if elm != nil && elm.Text() != "http://example.com/path" {
+		t.Errorf(`Failed to generate xml thats deferrent value in loc element: %v`, elm.Text())
+	}
+
+	elm = url.SelectElement("priority")
+	if elm != nil {
+		t.Errorf(`Failed to generate xml that omits the default priority element: %v`, elm)
+	}
+
+	elm = url.SelectElement("changefreq")
+	if elm != nil {
+		t.Errorf(`Failed to generate xml that omits the default changefreq element: %v`, elm)
+	}
+
+	elm = url.SelectElement("lastmod")
+	if elm != nil {
+		t.Errorf(`Failed to generate xml that omits the default lastmod element: %v`, elm)
+	}
+}
+
 func BenchmarkGenerateXML(b *testing.B) {
 
 	b.ReportAllocs()

--- a/stm/options.go
+++ b/stm/options.go
@@ -18,17 +18,20 @@ func NewOptions() *Options {
 
 // Options exists for the Sitemap struct.
 type Options struct {
-	defaultHost  string
-	sitemapsHost string
-	publicPath   string
-	sitemapsPath string
-	filename     string
-	verbose      bool
-	compress     bool
-	pretty       bool
-	adp          Adapter
-	nmr          *Namer
-	loc          *Location
+	defaultHost           string
+	sitemapsHost          string
+	publicPath            string
+	sitemapsPath          string
+	filename              string
+	verbose               bool
+	compress              bool
+	pretty                bool
+	adp                   Adapter
+	nmr                   *Namer
+	loc                   *Location
+	omitDefaultLastMod    bool
+	omitDefaultChangeFreq bool
+	omitDefaultPriority   bool
 }
 
 // SetDefaultHost sets that arg from Sitemap.Finalize method
@@ -74,6 +77,21 @@ func (opts *Options) SetPretty(pretty bool) {
 // SetAdapter sets that arg from Sitemap.SetAdapter method
 func (opts *Options) SetAdapter(adp Adapter) {
 	opts.adp = adp
+}
+
+// SetOmitDefaultLastMod controls whether to output a lastmod XML entity when none is provided in the URL builder
+func (opts *Options) SetOmitDefaultLastMod(omit bool) {
+	opts.omitDefaultLastMod = omit
+}
+
+// SetOmitDefaultChangeFreq controls whether to output a changefreq XML entity when none is provided in the URL builder
+func (opts *Options) SetOmitDefaultChangeFreq(omit bool) {
+	opts.omitDefaultChangeFreq = omit
+}
+
+// SetOmitDefaultPriority controls whether to output a Priority XML entity when none is provided in the URL builder
+func (opts *Options) SetOmitDefaultPriority(omit bool) {
+	opts.omitDefaultPriority = omit
 }
 
 // SitemapsHost sets that arg from Sitemap.SitemapsHost method


### PR DESCRIPTION
This allows for the explicit removal of `lastmod`, `priority`, and `changefreq` XML nodes, rather than setting them to default values.

Usage:

```go
opts := Options{}
opts.SetOmitDefaultLastMod(true)
opts.SetOmitDefaultPriority(true)
opts.SetOmitDefaultChangeFreq(true)
```

Since these three fields are largely ignored, this cuts down on the size of the generated XML files.

Reference:

* [Google: We Mostly Ignore The LastMod Tag In XML Sitemaps](https://www.seroundtable.com/google-lastmod-xml-sitemap-20579.html)
* [Google: Priority & Change Frequency In Sitemap Doesn't Play Much Of A Role](https://www.seroundtable.com/google-priority-change-frequency-xml-sitemap-20273.html)