### PR TITLE
Add: date_format option(RFC3339->yyyy-mm-dd)

### DIFF
--- a/stm/builder_indexurl.go
+++ b/stm/builder_indexurl.go
@@ -26,7 +26,7 @@ func (su *sitemapIndexURL) XML() []byte {
 
 	if _, ok := SetBuilderElementValue(sitemap, su.data, "lastmod"); !ok {
 		lastmod := sitemap.CreateElement("lastmod")
-		lastmod.SetText(time.Now().Format(time.RFC3339))
+		lastmod.SetText(time.Now().Format("2006-01-02"))
 	}
 
 	if su.opts.pretty {

--- a/stm/builder_indexurl.go
+++ b/stm/builder_indexurl.go
@@ -26,7 +26,10 @@ func (su *sitemapIndexURL) XML() []byte {
 
 	if _, ok := SetBuilderElementValue(sitemap, su.data, "lastmod"); !ok {
 		lastmod := sitemap.CreateElement("lastmod")
-		lastmod.SetText(time.Now().Format("2006-01-02"))
+		lastmod.SetText(time.Now().Format(time.RFC3339))
+		if su.opts.dateFormatYYYYMMDD {
+			lastmod.SetText(time.Now().Format("2006-01-02"))
+		}
 	}
 
 	if su.opts.pretty {

--- a/stm/builder_url.go
+++ b/stm/builder_url.go
@@ -99,7 +99,10 @@ func (su *sitemapURL) XML() []byte {
 	SetBuilderElementValue(url, su.data.URLJoinBy("loc", "host", "loc"), "loc")
 	if _, ok := SetBuilderElementValue(url, su.data, "lastmod"); !ok {
 		lastmod := url.CreateElement("lastmod")
-		lastmod.SetText(time.Now().Format("2006-01-02"))
+		lastmod.SetText(time.Now().Format(time.RFC3339))
+		if su.opts.dateFormatYYYYMMDD {
+			lastmod.SetText(time.Now().Format("2006-01-02"))
+		}
 	}
 	if _, ok := SetBuilderElementValue(url, su.data, "changefreq"); !ok {
 		changefreq := url.CreateElement("changefreq")

--- a/stm/builder_url.go
+++ b/stm/builder_url.go
@@ -99,7 +99,7 @@ func (su *sitemapURL) XML() []byte {
 	SetBuilderElementValue(url, su.data.URLJoinBy("loc", "host", "loc"), "loc")
 	if _, ok := SetBuilderElementValue(url, su.data, "lastmod"); !ok {
 		lastmod := url.CreateElement("lastmod")
-		lastmod.SetText(time.Now().Format(time.RFC3339))
+		lastmod.SetText(time.Now().Format("2006-01-02"))
 	}
 	if _, ok := SetBuilderElementValue(url, su.data, "changefreq"); !ok {
 		changefreq := url.CreateElement("changefreq")

--- a/stm/options.go
+++ b/stm/options.go
@@ -18,17 +18,18 @@ func NewOptions() *Options {
 
 // Options exists for the Sitemap struct.
 type Options struct {
-	defaultHost  string
-	sitemapsHost string
-	publicPath   string
-	sitemapsPath string
-	filename     string
-	verbose      bool
-	compress     bool
-	pretty       bool
-	adp          Adapter
-	nmr          *Namer
-	loc          *Location
+	defaultHost        string
+	sitemapsHost       string
+	publicPath         string
+	sitemapsPath       string
+	filename           string
+	verbose            bool
+	compress           bool
+	pretty             bool
+	adp                Adapter
+	nmr                *Namer
+	loc                *Location
+	dateFormatYYYYMMDD bool
 }
 
 // SetDefaultHost sets that arg from Sitemap.Finalize method
@@ -74,6 +75,11 @@ func (opts *Options) SetPretty(pretty bool) {
 // SetAdapter sets that arg from Sitemap.SetAdapter method
 func (opts *Options) SetAdapter(adp Adapter) {
 	opts.adp = adp
+}
+
+// SetDateFormatYYYYMMD controls whether to output a Priority XML entity when none is provided in the URL builder
+func (opts *Options) SetDateFormatYYYYMMDD(yyyymmdd bool) {
+	opts.dateFormatYYYYMMDD = yyyymmdd
 }
 
 // SitemapsHost sets that arg from Sitemap.SitemapsHost method

--- a/stm/utils.go
+++ b/stm/utils.go
@@ -82,7 +82,7 @@ func SetBuilderElementValue(elm *etree.Element, data [][]interface{}, basekey st
 		child.SetText(fmt.Sprint(value))
 	case time.Time:
 		child = elm.CreateElement(key)
-		child.SetText(value.Format(time.RFC3339))
+		child.SetText(value.Format("2006-01-02"))
 	case bool:
 		_ = elm.CreateElement(fmt.Sprintf("%s:%s", key, key))
 	case []int:

--- a/stm/utils.go
+++ b/stm/utils.go
@@ -82,7 +82,7 @@ func SetBuilderElementValue(elm *etree.Element, data [][]interface{}, basekey st
 		child.SetText(fmt.Sprint(value))
 	case time.Time:
 		child = elm.CreateElement(key)
-		child.SetText(value.Format("2006-01-02"))
+		child.SetText(value.Format(time.RFC3339))
 	case bool:
 		_ = elm.CreateElement(fmt.Sprintf("%s:%s", key, key))
 	case []int:


### PR DESCRIPTION
Looking at 
[google](https://developers.google.com/search/docs/advanced/sitemaps/build-sitemap) and the [sitemap.org](https://www.sitemaps.org/protocol.html),
 it seems that `lastmod` date_format is more often used in `yyyy-mm-dd` than `RFC3339`, so I propose a fix for the optional setting of date_format.

According to [w3c,](https://www.w3.org/TR/NOTE-datetime) datetime_format is optional.
```
Year:
    YYYY (eg 1997)
Year and month:
    YYYY-MM (eg 1997-07)
Complete date:
    YYYY-MM-DD (eg 1997-07-16)
Complete date plus hours and minutes:
    YYYY-MM-DDThh:mmTZD (eg 1997-07-16T19:20+01:00)
Complete date plus hours, minutes and seconds:
    YYYY-MM-DDThh:mm:ssTZD (eg 1997-07-16T19:20:30+01:00)
Complete date plus hours, minutes, seconds and a decimal fraction of a second
    YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45+01:00)
```

Usage:
```
opts := Options{}
opts.SetDateFormatYYYYMMDD(true)
````