### PR TITLE
Remove bing (no longer active)

### DIFF
--- a/stm/ping.go
+++ b/stm/ping.go
@@ -10,7 +10,6 @@ import (
 func PingSearchEngines(opts *Options, urls ...string) {
 	urls = append(urls, []string{
 		"http://www.google.com/webmasters/tools/ping?sitemap=%s",
-		"http://www.bing.com/webmaster/ping.aspx?siteMap=%s",
 	}...)
 	sitemapURL := opts.IndexLocation().URL()
 


### PR DESCRIPTION
I remove bing because it's anonymous sitemap submission no longer active: https://blogs.bing.com/webmaster/may-2022/Spring-cleaning-Removed-Bing-anonymous-sitemap-submission